### PR TITLE
Fix usage of "hasattr()" with the "CoralogixLogger" handler

### DIFF
--- a/coralogix/handlers/coralogix.py
+++ b/coralogix/handlers/coralogix.py
@@ -172,7 +172,7 @@ class CoralogixLogger(Handler):
             return wrapper
         else:
             DebugLogger.error('Invalid severity name "{0:s}"!'.format(severity.lower()))
-            raise NotImplementedError('Severity name is invalid!')
+            raise AttributeError('Severity name is invalid!')
 
     @staticmethod
     def flush_messages():

--- a/coralogix/tests/test_coralogix.py
+++ b/coralogix/tests/test_coralogix.py
@@ -48,7 +48,7 @@ class TestCoralogixLogger(TestCase):
         )
 
     def test_fault_log_severity(self):
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(AttributeError):
             self.create_logger().__getattr__('invalid')(
                 Coralogix.Severity.DEBUG,
                 'Test message!'


### PR DESCRIPTION
Hi.

I'm the author of a logging library and a user reported compatibility issue with the `CoralogixLogger()` class.

This is because I'm using [`hasattr()`](https://docs.python.org/3/library/functions.html#hasattr) to inspect different properties of the handler passed to my library. Unfortunately, because `CoralogixLogger.__getattr__()` might raise a `NotImplementedError`, my `hasattr()` check fails instead of returning `False`.

I would like to suggest to raise an `AttributeError` in `__getattr__()` to fix the behavior of `hasattr()`. According to the documentation, [`__getattr__()`](https://docs.python.org/3/reference/datamodel.html#object.__getattr__) isn't expected to raise anything but `AttributeError` exception (emphasis mine):

> Called when the default attribute access fails with an [`AttributeError`](https://docs.python.org/3/library/exceptions.html#AttributeError) (either [`__getattribute__()`](https://docs.python.org/3/reference/datamodel.html#object.__getattribute__) raises an [`AttributeError`](https://docs.python.org/3/library/exceptions.html#AttributeError) because name is not an instance attribute or an attribute in the class tree for self; or [`__get__()`](https://docs.python.org/3/reference/datamodel.html#object.__get__) of a name property raises [`AttributeError`](https://docs.python.org/3/library/exceptions.html#AttributeError)). **This method should either return the (computed) attribute value or raise an [`AttributeError`](https://docs.python.org/3/library/exceptions.html#AttributeError) exception.**
