### PR TITLE
Update README to link to the correct docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,4 +41,4 @@ Coralogix Python SDK
     :target: https://github.com/coralogix/python-coralogix-sdk/graphs/contributors
 
 This package provides logging suites integrated with `Coralogix` logs analytics platform.
-For watch how to use it, please, read `Coralogix Python SDK Docs <https://python-coralogix-sdk.readthedocs.io/en/latest/>`_.
+To see how to use it, please read `Coralogix Python SDK Docs <https://coralogix.com/docs/integrations/sdks/python-sdk/>`_.


### PR DESCRIPTION
The readthedocs.io docs are out of date and missing the crucial info that `CORALOGIX_LOG_URL` must be set; we should link to the coralogix.com ones instead.